### PR TITLE
Fix link to credo

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To install bunt:
 
 To install credo:
 
-    git clone https://github.com/dlpil/credo
+    git clone https://github.com/rrrene/credo
     cd credo
     mix archive.build
     mix archive.install


### PR DESCRIPTION
This fixes the wrong github URL to credo.
Greetings from the elixir.cologne usergroup, where we live-fixed that :)

Reviewed by:

@rrrene
@splattael
@rafaelteixeira
@killercup
@timbuchwaldt
@rhazdon
@bassorama
@solidnerd
@mhmoudgmal
@mobbit
