### PR TITLE
fix(Mix) use `:working-directory`

### DIFF
--- a/flycheck-elixir-credo.el
+++ b/flycheck-elixir-credo.el
@@ -44,6 +44,8 @@
   "Defines a checker for elixir with credo"
   :command ("mix" "credo" "--format" "flycheck" source-inplace)
   :standard-input t
+  :working-directory (lambda (checker)
+                       (locate-dominating-file default-directory "mix.exs"))
   :error-patterns
   (
    (info line-start (file-name) ":" line ":" column ": " (or "F" "R" "C")  ": " (message) line-end)


### PR DESCRIPTION
Use flycheck's `:working-directory` lambda to find the appropriate
directory in which to run `mix credo`

The global installation of credo wasn't working properly for me, but a
local `mix credo` worked, and this change makes this plugin work
properly in my elixir projects
